### PR TITLE
implemented rnns in equinox

### DIFF
--- a/pebble/models/rnn.py
+++ b/pebble/models/rnn.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass
+import jax.numpy as jnp
+import jax
+from jax import random as jrandom
+import equinox as eqx
+import equinox.nn as enn
+from jax import vmap, jit, grad, lax
+from typing import List, Callable
+from functools import reduce
+
+@dataclass
+class MLPConfig:
+    in_dim: int = 2
+    out_dim: int = 1
+    width: int = 40
+    depth: int = 2 # note: depth is the #(linear layers), and #(hidden layers) = #(linear layers) - 1.
+    activation: Callable = jax.nn.silu
+    
+class MLP(eqx.Module):
+
+    layers: List[enn.Linear]
+    activation: Callable
+
+    def __init__(self, config, key):
+        keys = jrandom.split(key, config.depth)
+        shp = [config.in_dim] + [config.width]*(config.depth-1) + [config.out_dim]
+        self.activation = config.activation
+        self.layers = [enn.Linear(shp[i], shp[i+1], key=keys[i]) for i in range(config.depth)]
+        
+    def __call__(self, x):
+        out = reduce(lambda acc, layer: self.activation(vmap(layer)(acc)), self.layers[:-1], x)
+        return vmap(self.layers[-1])(out)
+        
+    
+@dataclass
+class RNNConfig:
+    input_dim: int = 2
+    output_dim: int = 1
+    hidden_dim: int = 40
+    
+    
+class RNN(eqx.Module):
+    hidden_dim: int
+    Wh: enn.Linear
+    Wx: enn.Linear
+    Wy: enn.Linear
+    act: Callable
+
+    def __init__(self, config, key):
+        wh_key, wx_key, wy_key = jrandom.split(key, 3)
+        self.hidden_dim = config.hidden_dim
+        self.Wh = enn.Linear(config.hidden_dim, config.hidden_dim, key=wh_key)
+        self.Wx = enn.Linear(config.input_dim, config.hidden_dim, key=wx_key)
+        self.Wy = enn.Linear(config.hidden_dim, config.output_dim, key=wy_key)
+        self.act = jax.nn.sigmoid
+    
+    def __call__(self, x):
+        # x shape: (batch size, sequence length, input_dim)
+        batch_size = x.shape[0]
+
+        hidden = jnp.zeros((batch_size, self.hidden_dim))
+
+        def rnn_step(h, input):
+            h = self.act(self.Wh(h) + self.Wx(input))
+            return h, self.Wy(h)
+        
+        def rnn_step_batched(h_batch, input_batch):
+            return lax.scan(rnn_step, h_batch, input_batch)
+
+        hidden, out = vmap(rnn_step_batched, in_axes=(0, 0))(hidden, x)
+        # out shape: (batch_size, sequence_length, output_dim)
+        return out
+
+
+# let's make a more general RNN where we can have an arbitrarily-complex MLP
+# as the hidden state transition function and the output function
+@dataclass
+class GeneralRNNConfig:
+    input_dim: int = 2
+    output_dim: int = 1
+    hidden_dim: int = 40
+    hidden_mlp_depth: int = 2 # this would be 1 hidden layer
+    hidden_mlp_width: int = 100
+    output_mlp_depth: int = 2 # this would be 1 hidden layer
+    output_mlp_width: int = 100
+    activation: Callable = jax.nn.silu
+
+class GeneralRNN(eqx.Module):
+    hidden_dim: int
+    input_dim: int
+    hmlp: MLP
+    ymlp: MLP
+
+    def __init__(self, config, key):
+        key_hmlp, key_ymlp = jrandom.split(key)
+        self.hidden_dim = config.hidden_dim
+        self.input_dim = config.input_dim
+        hmlp_config = MLPConfig(
+            config.hidden_dim + config.input_dim, 
+            config.hidden_dim, 
+            config.hidden_mlp_width, 
+            config.hidden_mlp_depth, 
+            config.activation
+        )
+        self.hmlp = MLP(hmlp_config, key_hmlp)
+        ymlp_config = MLPConfig(
+            config.hidden_dim, 
+            config.output_dim, 
+            config.output_mlp_width, 
+            config.output_mlp_depth, 
+            config.activation
+        )
+        self.ymlp = MLP(ymlp_config, key_ymlp)
+
+    def __call__(self, x, h=None):
+        """The transition is given by:
+            h_t = f([h_{t-1}, x_t])
+            y_t = g(h_t)
+        where f and g are MLPs.
+
+        This function takes in the input and the hidden state and 
+        returns an output and a hidden state.
+        """
+        # x shape: (batch_size, input_dim)
+        # h shape: (batch_size, hidden_dim)
+        if h is None:
+            h = jnp.zeros((x.shape[0], self.hidden_dim))
+        else:
+            assert h.shape[0] == x.shape[0]
+            assert h.shape[1] == self.hidden_dim
+        assert x.shape[1] == self.input_dim
+        hx = jnp.concatenate((h, x), axis=1)
+        h = self.hmlp(hx)
+        y = self.ymlp(h)
+        return y, h
+    
+    def forward_sequence(self, x):
+        """This function takes in a sequence of inputs and returns a sequence of outputs
+        as well as the final hidden state."""
+        # x shape: (batch_size, sequence_length, input_dim)
+        batch_size = x.shape[0]
+        hidden = jnp.zeros((batch_size, self.hidden_dim))
+        assert x.shape[2] == self.input_dim
+
+        def rnn_step(h, input):
+            y, h = self(input, h)
+            return h, y
+
+        # out shape: (batch_size, sequence_length, output_dim)
+        hidden, out = lax.scan(rnn_step, hidden, jnp.transpose(x, (1, 0, 2)))
+        return jnp.transpose(out, (1, 0, 2)), hidden

--- a/pebble/models/test_rnn.ipynb
+++ b/pebble/models/test_rnn.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "import rnn\n",
+    "importlib.reload(rnn)\n",
+    "\n",
+    "config = rnn.MLPConfig()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from jax import random as jrandom\n",
+    "key = jax.random.PRNGKey(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp = rnn.MLP(config, key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 159,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MLP(\n",
+       "  layers=[\n",
+       "    Linear(\n",
+       "      weight=f32[40,2],\n",
+       "      bias=f32[40],\n",
+       "      in_features=2,\n",
+       "      out_features=40,\n",
+       "      use_bias=True\n",
+       "    ),\n",
+       "    Linear(\n",
+       "      weight=f32[1,40],\n",
+       "      bias=f32[1],\n",
+       "      in_features=40,\n",
+       "      out_features=1,\n",
+       "      use_bias=True\n",
+       "    )\n",
+       "  ],\n",
+       "  activation=<wrapped function silu>\n",
+       ")"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mlp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = jnp.array([[[1, 2], [3, 4], [3, 4]],[[1, 2], [3, 4], [3, 4]]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2, 3, 2)"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([[0.7476651 ],\n",
+       "       [0.91087353],\n",
+       "       [0.91087353]], dtype=float32)"
+      ]
+     },
+     "execution_count": 162,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mlp(x_f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array([[1, 2],\n",
+       "       [1, 2]], dtype=int32)"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x[:, 0, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RNNConfig(input_dim=2, output_dim=1, hidden_dim=40)"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rnn_config = rnn.RNNConfig()\n",
+    "rnn_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = rnn.RNN(rnn_config, key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h, out = model(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2, 3, 1)"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2, 40)"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GeneralRNNConfig(input_dim=2, output_dim=1, hidden_dim=40, hidden_mlp_depth=2, hidden_mlp_width=100, output_mlp_depth=2, output_mlp_width=100, activation=<PjitFunction of <function silu at 0x14735aca0>>)"
+      ]
+     },
+     "execution_count": 175,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grnn_config = rnn.GeneralRNNConfig()\n",
+    "grnn_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grnn = rnn.GeneralRNN(grnn_config, key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_f = jnp.array([[1, 2], [3, 4], [3, 4]])\n",
+    "x_fs = jnp.array([[[1, 2], [3, 4], [3, 4]],[[1, 2], [3, 4], [3, 4]]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y, h = grnn(x_f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((3, 1), (3, 40))"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y.shape, h.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_s, h_s = grnn.forward_sequence(x_fs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((2, 3, 1), (2, 40))"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_s.shape, h_s.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Added a folder under pebble called models, and implemented a module called rnn.py. Implements the RNNs from the original codebase in equinox. Specifically, implements MLP, RNN, and GeneralRNN.
Notes: 
- Also pushed test_rnn.ipynb which just demonstrates how to do the forward pass for each neural net. 
- Need to jit and optimize later, may have some problems with functools reduce (need to verify)
